### PR TITLE
Set a timeout of 3min.

### DIFF
--- a/www/update.js
+++ b/www/update.js
@@ -209,6 +209,7 @@ var update = {
 
         var manifestUrl = update.apiUrl + '/' + update.updateDomain + '/v1/manifest';
         update.debug("FETCHING MANIFEST FROM " + manifestUrl + " FOR DOMAIN " + update.domain);
+        update.http.setRequestTimeout(180); // 3min timeout
         update.http.get(manifestUrl, {}, { 'domain': update.domain }, function(response) {
 
             try {


### PR DESCRIPTION
Get manifest takes 2 min before gateway timeout.   Wait at least 3min.